### PR TITLE
Allow passing of revealService to CollectionScrollView

### DIFF
--- a/addon/components/collection-scroll-view/component.js
+++ b/addon/components/collection-scroll-view/component.js
@@ -16,6 +16,7 @@ export default class CollectionScrollView extends EmberCollection {
   @argument @type(optional('number')) scrollTopOffset = 0;
   @argument @type(optional('number')) initialScrollTop;
   @argument @type(optional('string')) key;
+  @argument @type(optional('any')) revealService;
 
   @action
   scrollChange(scrollTop) {
@@ -41,4 +42,27 @@ export default class CollectionScrollView extends EmberCollection {
       this.scrolledToTopChange(isAtTop);
     }
   }
+
+  @action
+  scrollToItem(scrollViewApi, revealItemPayload) {
+    let { id, source } = revealItemPayload;
+    if (source && isChildComponent(this, source)) {
+      return;
+    }
+    let itemIndex = this.items.indexOf(this.items.findBy('id', id));
+    if (itemIndex >= 0) {
+      let { y } = this._cellLayout.positionAt(itemIndex);
+      scrollViewApi.scrollTo(y, true);
+    }
+  }
+}
+
+function isChildComponent(component, candidateChildComponent) {
+  let parentView  = candidateChildComponent;
+  while (parentView = parentView.parentView) { // eslint-disable-line no-cond-assign
+    if (parentView === component) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/addon/components/collection-scroll-view/template.hbs
+++ b/addon/components/collection-scroll-view/template.hbs
@@ -11,6 +11,13 @@
   {{~#each _cells as |cell|~}}
     <div style={{{cell.style}}}>{{yield cell.item cell.index}}</div>
   {{~/each~}}
+  {{#if revealService}}
+    {{emitter-action
+        emitter=revealService
+        eventName="revealItemById"
+        action=(action 'scrollToItem' scrollViewApi)
+    }}
+  {{/if}}
 </ScrollView>
 
 {{#if auxiliaryComponent}}

--- a/addon/components/emitter-action/component.js
+++ b/addon/components/emitter-action/component.js
@@ -48,8 +48,9 @@ export default class EmitterAction extends Component {
   }
 
   _action() {
+    let args = arguments;
     join(() => {
-      this.action();
+      this.action(...args);
     });
   }
 }

--- a/addon/utils/scroll-view-api.js
+++ b/addon/utils/scroll-view-api.js
@@ -9,6 +9,7 @@ export default EmberObject.extend(Evented, {
     this.scrollToBottom = _scrollComponent.scrollToBottom.bind(_scrollComponent);
     this.scrollToElement = _scrollComponent.scrollToElement.bind(_scrollComponent);
     this.scrollToTop = _scrollComponent.scrollToTop.bind(_scrollComponent);
+    this.scrollTo = _scrollComponent.scrollTo.bind(_scrollComponent);
     this.scrollToTopIfInViewport = _scrollComponent.scrollToTopIfInViewport.bind(_scrollComponent);
     this.scheduleRefresh = _scrollComponent.scheduleRefresh.bind(_scrollComponent);
     this.getViewHeight = _scrollComponent.getViewHeight.bind(_scrollComponent);


### PR DESCRIPTION
- service is listened on for a revealItemById event, which is expected to be fired with a payload that contains an id property
- CollectionScrollView responds to event by scrolling item into view