### PR TITLE
Improve gesture detection

### DIFF
--- a/addon/components/scroll-view.js
+++ b/addon/components/scroll-view.js
@@ -23,6 +23,24 @@ let waiter = buildWaiter('yapp-scroll-view:scrolling');
 const FIELD_REGEXP = /input|textarea|select/i;
 const MEASUREMENT_INTERVAL = 250;
 const MEASUREMENT_INTERVAL_WHILE_SCROLLING_OR_OFFSCREEN = 1000;
+const LONG_PRESS_DELAY = 500;
+const GHOST_CLICK_DELAY = 100;
+
+const isIPhone = /iPhone|iPod|iPad/i.test(navigator.appVersion);
+
+let timeoutID = 0;
+function addCaptureClick(domElement) {
+  if(timeoutID) {
+    clearTimeout(timeoutID);
+  } else {
+    domElement.addEventListener('click', captureClick, true);
+  }
+  let cancelCaptureClick = () => {
+    timeoutID = 0;
+    domElement.removeEventListener('click', captureClick, true);
+  }
+  timeoutID = setTimeout(cancelCaptureClick, GHOST_CLICK_DELAY)
+}
 
 function debounce(func, wait, immediate) {
   var timeout;
@@ -293,13 +311,18 @@ class ScrollView extends Component {
 
     if (preventClick) {
       // A touchend event can prevent a follow-on click event by calling preventDefault.
-      // However, a mouseup event cannot do this so we need to capture the upcoming click instead.
-      if (event instanceof MouseEvent) {
-        this.scrollViewElement.addEventListener('click', captureClick, true);
-      } else {
-        event.preventDefault();
-        event.stopPropagation();
+      // On Android, it works well.
+      // On iOS, we see a click event being triggered after a touchend event,
+      // even when `preventDefault` and `stopPropagation` were called. However, phantom clicks
+      // are not triggered consistently. In order to avoid capturing legit click events,
+      // we only try to capture phantom clicks if they happen less than 100ms after a touchend event.
+      // On desktop browsers, a mouseup event cannot do this so we need to capture the upcoming click instead.
+
+      if (isIPhone || (event instanceof MouseEvent)) {
+        addCaptureClick(this.scrollViewElement);
       }
+      event.preventDefault();
+      event.stopPropagation();
     }
 
     this._touchStartTimeStamp = null;
@@ -310,6 +333,7 @@ class ScrollView extends Component {
     // There are three cases where we want to prevent the click that normally follows a mouseup/touchend.
     //
     // 1) when the user is just finishing a purposeful scroll (i.e. dragging scroll view beyond a threshold)
+    //    This is only true on a desktop.
     // 2) when animating with "momentum", a tap should stop the movement rather than
     //    trigger an interactive element that may be under the tap. Zynga scroller
     //    takes care of stopping the movement, but we need to capture the click
@@ -321,7 +345,7 @@ class ScrollView extends Component {
     let wasAnimatingWithMomentum =
       this._wasScrollingAtTouchStart &&
       Math.abs(this._decelerationVelocityY) > 2;
-    let isLongPress = touchDuration > 500
+    let isLongPress = touchDuration > LONG_PRESS_DELAY;
     return isFinishingDragging || wasAnimatingWithMomentum || isLongPress;
   }
 


### PR DESCRIPTION
- A long press does not trigger a click event.
I picked 500 ms based on Apple's [definition](https://developer.apple.com/documentation/uikit/touches_presses_and_gestures/handling_uikit_gestures/handling_long-press_gestures)
![c57fc4b9-4419-4ef9-9067-d27f474504af](https://user-images.githubusercontent.com/743977/180576905-358b0204-51ce-49ba-a2d5-2fc30f6567fd.png)


- Prevent ghost click when panning on iOS
I picked 100 ms as an arbitrary value. During my tests, they happened within 70-80 ms. I rounded to 100 ms to have a buffer. I also noticed that most of my clicks following a previous action would happen about 300 ms after.

[Trello card](https://trello.com/c/TNEF9HQt/6128-mobile-after-triggering-a-momentum-scrolling-touching-the-screen-should-stop-scrolling-not-click)

I didn't write a test as the project is not connected to CircleCI and `master` already doesn't pass. We'll need to invest into it if that's a priority.