### PR TITLE
[BUG] Clicking on an input, textarea or select works

### DIFF
--- a/addon/components/scroll-view.js
+++ b/addon/components/scroll-view.js
@@ -307,7 +307,11 @@ class ScrollView extends Component {
   }
 
   doTouchEnd(_touches, timeStamp, event) {
-    let preventClick = this.needsPreventClick(timeStamp - this._touchStartTimeStamp);
+    // In most cases, `doTouchStart` is being called before `doTouchEnd`, allowing to set `_touchStartTimeStamp`
+    // It is not true when the event occurs on some elements (`input`, `textarea`, or `select`) which can be scrolled.
+    // In this case, `ZyngaScrollerVerticalOrganizer` will not call `doTouchStart`
+    let touchDuration = this._touchStartTimeStamp ? (timeStamp - this._touchStartTimeStamp) : 0;
+    let preventClick = this.needsPreventClick(touchDuration);
 
     if (preventClick) {
       // A touchend event can prevent a follow-on click event by calling preventDefault.


### PR DESCRIPTION
Textarea, input, and select element can be scrollable too.
`ZyngaScrollerVerticalRecognizer` will not call `doTouchStart` when they are inside a ScrollView.

To prevent the long press detection to flag the click as a ghost one, we just set the touch duration to 0 in this case.
