### PR TITLE
Register test waiters for CollectionScrollView async cycles

### DIFF
--- a/src/components/collection-scroll-view.gjs
+++ b/src/components/collection-scroll-view.gjs
@@ -7,9 +7,12 @@ import { VerticalCollection } from '@html-next/vertical-collection';
 import { on } from '@ember/modifier';
 import onResize from 'ember-on-resize-modifier/modifiers/on-resize';
 import { or } from 'ember-truth-helpers';
+import { buildWaiter } from '@ember/test-waiters';
 import emitterAction from '../helpers/emitter-action.js';
 
 const MAX_PENDING_RESTORE_ATTEMPTS = 5;
+
+const waiter = buildWaiter('yapp-scroll-view:collection-scroll-view');
 
 export default class CollectionScrollView extends Component {
   @service('scroll-position-memory') memory;
@@ -115,6 +118,11 @@ export default class CollectionScrollView extends Component {
     if (this._restoreRafId) {
       cancelAnimationFrame(this._restoreRafId);
       this._restoreRafId = null;
+    }
+    this._endRestoreWaiterToken();
+    if (this._verticalCollectionRefreshWaiterToken) {
+      waiter.endAsync(this._verticalCollectionRefreshWaiterToken);
+      this._verticalCollectionRefreshWaiterToken = null;
     }
     this.scrollElement = null;
   }
@@ -224,7 +232,12 @@ export default class CollectionScrollView extends Component {
     }
 
     // Wait one frame for VC to re-render before notifying consumers.
-    await new Promise((resolve) => requestAnimationFrame(resolve));
+    let scrollToItemToken = waiter.beginAsync();
+    try {
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+    } finally {
+      waiter.endAsync(scrollToItemToken);
+    }
 
     this.args.onScrollToItem?.({
       id,
@@ -266,15 +279,24 @@ export default class CollectionScrollView extends Component {
       return;
     }
     this._verticalCollectionRefreshScheduled = true;
+    this._verticalCollectionRefreshWaiterToken = waiter.beginAsync();
     scheduleOnce('afterRender', this, this.dispatchVerticalCollectionRefresh);
   }
 
   dispatchVerticalCollectionRefresh() {
     this._verticalCollectionRefreshScheduled = false;
-    if (typeof window === 'undefined') {
-      return;
+    let token = this._verticalCollectionRefreshWaiterToken;
+    this._verticalCollectionRefreshWaiterToken = null;
+    try {
+      if (typeof window === 'undefined') {
+        return;
+      }
+      window.dispatchEvent(new Event('resize'));
+    } finally {
+      if (token) {
+        waiter.endAsync(token);
+      }
     }
-    window.dispatchEvent(new Event('resize'));
   }
 
   storeScrollPosition() {
@@ -313,15 +335,33 @@ export default class CollectionScrollView extends Component {
     ) {
       if (hasReachedMaxAttempts) {
         this._pendingRestorePosition = undefined;
+        this._endRestoreWaiterToken();
       }
       return;
     }
     this._pendingRestoreAttempts = (this._pendingRestoreAttempts ?? 0) + 1;
     this._restoreScheduled = true;
+    if (!this._restoreWaiterToken) {
+      this._restoreWaiterToken = waiter.beginAsync();
+    }
     this._restoreRafId = requestAnimationFrame(() => {
       this._restoreRafId = null;
-      this.applyPendingRestore();
+      try {
+        this.applyPendingRestore();
+      } finally {
+        if (!this._restoreScheduled) {
+          this._endRestoreWaiterToken();
+        }
+      }
     });
+  }
+
+  _endRestoreWaiterToken() {
+    let token = this._restoreWaiterToken;
+    this._restoreWaiterToken = null;
+    if (token) {
+      waiter.endAsync(token);
+    }
   }
 
   applyPendingRestore() {

--- a/tests/integration/components/collection-scroll-view-test.js
+++ b/tests/integration/components/collection-scroll-view-test.js
@@ -388,6 +388,80 @@ module('Integration | Component | collection-scroll-view', function (hooks) {
     );
   });
 
+  test('settled() covers the initial scroll-position restore RAF', async function (assert) {
+    this.set('isLoading', true);
+
+    await render(hbs`
+      <div style={{html-safe (concat "width:" this.viewportWidth "px; height:" this.viewportHeight "px; position:relative; --item-height:" this.itemHeight "px; display:flex; flex-direction:column;")}}>
+        <CollectionScrollView
+          @items={{this.items}}
+          @estimateItemHeight={{this.itemHeight}}
+          @estimatedHeight={{this.viewportHeight}}
+          @estimatedWidth={{this.viewportWidth}}
+          @buffer={{1}}
+          @cellLayout={{fixed-grid-layout 320 100}}
+          @initialScrollTop={{520}}
+          @isLoading={{this.isLoading}}
+        >
+          <:row as |item|>
+            <div class="list-item" data-list-item-id={{item.id}}>
+              {{item.name}}
+            </div>
+          </:row>
+        </CollectionScrollView>
+      </div>
+    `);
+
+    this.set('isLoading', false);
+    await settled();
+
+    assert.equal(
+      find(SCROLL_CONTAINER).scrollTop,
+      520,
+      'scroll position is restored after settled() without waitUntil polling',
+    );
+  });
+
+  test('settled() covers the scrollToItem RAF before onScrollToItem fires', async function (assert) {
+    let fakeRevealService = new FakeRevealService();
+    this.set('revealService', fakeRevealService);
+    let callbackArgs = null;
+    this.set('onScrollToItem', (args) => {
+      callbackArgs = args;
+    });
+    await render(hbs`
+      <div style={{html-safe (concat "width:" this.viewportWidth "px; height:" this.viewportHeight "px; position:relative; --item-height:" this.itemHeight "px; display:flex; flex-direction:column;")}}>
+        <CollectionScrollView
+          @items={{this.items}}
+          @estimateItemHeight={{this.itemHeight}}
+          @estimatedHeight={{this.viewportHeight}}
+          @estimatedWidth={{this.viewportWidth}}
+          @buffer={{1}}
+          @cellLayout={{fixed-grid-layout 320 100}}
+          @revealService={{this.revealService}}
+          @onScrollToItem={{this.onScrollToItem}}
+        >
+          <:row as |item|>
+            <div class="list-item" data-list-item-id={{item.id}}>
+              {{item.name}}
+            </div>
+          </:row>
+        </CollectionScrollView>
+      </div>
+    `);
+    await waitUntilText('One');
+
+    fakeRevealService.trigger('revealItemById', { id: '8' });
+    await settled();
+
+    assert.ok(
+      callbackArgs,
+      'onScrollToItem fires within settled() without waitUntil polling',
+    );
+    assert.equal(callbackArgs.id, '8');
+    assert.equal(callbackArgs.index, 7);
+  });
+
   test('it yields a public API as the third block param', async function (assert) {
     await render(hbs`
       <div style={{html-safe (concat "width:" this.viewportWidth "px; height:" this.viewportHeight "px; position:relative; --item-height:" this.itemHeight "px; display:flex; flex-direction:column;")}}>


### PR DESCRIPTION
## Summary

- Wrap three untracked async cycles in `CollectionScrollView` with an `@ember/test-waiters` waiter so `await settled()` covers them:
  - `scheduleVerticalCollectionRefresh` → `afterRender` → dispatched resize event
  - `schedulePendingRestore` RAF chain (held across retries until restore completes or bails at max attempts)
  - `scrollToItem`'s one-frame wait before `onScrollToItem` fires
- Release any held tokens in `willDestroy` so teardown can't leave `settled()` pending.
- Add two integration tests that exercise the waiters using `await settled()` alone (no `waitUntil` polling).

Closes [Y-1068](https://linear.app/yapp/issue/Y-1068).

## Test plan

- [x] `pnpm test` — all 53 integration tests pass
- [ ] Consumer validation: drop `timeout: 5000` / `waitFor` calls in `yapp-core/tests/acceptance/people/dynamic-test.js` and confirm stability under CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)